### PR TITLE
Xorg 1.20.3

### DIFF
--- a/common/backlight.c
+++ b/common/backlight.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/ioctl.h>
 
 #include <stdio.h>

--- a/common/unaccel.c
+++ b/common/unaccel.c
@@ -192,15 +192,6 @@ static void unaccel_fixup_tile(DrawablePtr pDraw, PixmapPtr *ppPix)
 {
 	PixmapPtr pNew, pPixmap = *ppPix;
 
-	if (pPixmap->drawable.bitsPerPixel != pDraw->bitsPerPixel) {
-		prepare_cpu_drawable(&pPixmap->drawable, CPU_ACCESS_RO);
-		pNew = fb24_32ReformatTile(pPixmap, pDraw->bitsPerPixel);
-		finish_cpu_drawable(&pPixmap->drawable, CPU_ACCESS_RO);
-
-		pDraw->pScreen->DestroyPixmap(pPixmap);
-		*ppPix = pPixmap = pNew;
-	}
-
 	if (FbEvenTile(pPixmap->drawable.width * pPixmap->drawable.bitsPerPixel)) {
 		prepare_cpu_drawable(&pPixmap->drawable, CPU_ACCESS_RW);
 		fbPadPixmap(pPixmap);

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+xf86-video-armada (0.0.1-r17) unstable; urgency=medium
+
+  [ Wade Cline ]
+  * Add support for xserver >=1.20
+
+ -- Wade Cline <wadecline@hotmail.com>  Thu, 22 Nov 2018 14:48:40 -0800
+
 xf86-video-armada (0.0.1-r16) unstable; urgency=medium
 
   [ Sean Cross ]

--- a/etnaviv/etnadrm_module.c
+++ b/etnaviv/etnadrm_module.c
@@ -27,7 +27,7 @@ static pointer etnadrm_setup(pointer module, pointer opts, int *errmaj,
 		return (pointer) 1;
 	}
 
-	*errmaj = LDR_NOHARDWARE;
+	*errmaj = LDR_MODSPECIFIC;
 	*errmin = 0;
 
 	return NULL;

--- a/etnaviv/etnaviv.c
+++ b/etnaviv/etnaviv.c
@@ -412,32 +412,6 @@ etnaviv_ValidateGC(GCPtr pGC, unsigned long changes, DrawablePtr pDrawable)
 {
 	struct etnaviv *etnaviv = etnaviv_get_screen_priv(pDrawable->pScreen);
 
-#ifdef FB_24_32BIT
-	if (changes & GCTile && fbGetRotatedPixmap(pGC)) {
-		pGC->pScreen->DestroyPixmap(fbGetRotatedPixmap(pGC));
-		fbGetRotatedPixmap(pGC) = NULL;
-	}
-	if (pGC->fillStyle == FillTiled) {
-		PixmapPtr pOldTile = pGC->tile.pixmap;
-		PixmapPtr pNewTile;
-
-		if (pOldTile->drawable.bitsPerPixel != pDrawable->bitsPerPixel) {
-			pNewTile = fbGetRotatedPixmap(pGC);
-			if (!pNewTile || pNewTile->drawable.bitsPerPixel != pDrawable->bitsPerPixel) {
-				if (pNewTile)
-					pGC->pScreen->DestroyPixmap(pNewTile);
-				prepare_cpu_drawable(&pOldTile->drawable, CPU_ACCESS_RO);
-				pNewTile = fb24_32ReformatTile(pOldTile, pDrawable->bitsPerPixel);
-				finish_cpu_drawable(&pOldTile->drawable, CPU_ACCESS_RO);
-			}
-			if (pNewTile) {
-				fbGetRotatedPixmap(pGC) = pOldTile;
-				pGC->tile.pixmap = pNewTile;
-				changes |= GCTile;
-			}
-		}
-	}
-#endif
 	if (changes & GCTile) {
 		if (!pGC->tileIsPixel &&
 		    FbEvenTile(pGC->tile.pixmap->drawable.width *

--- a/etnaviv/etnaviv_accel.c
+++ b/etnaviv/etnaviv_accel.c
@@ -334,7 +334,6 @@ static uint32_t etnaviv_fg_col(struct etnaviv *etnaviv, GCPtr pGC)
 			 scale16((pixel & 0x07e0) >> 5, 6) << 8 |
 			 scale16((pixel & 0x001f), 5);
 		break;
-	case 24: /* A8R8G8B8 */
 	default:
 		colour = pixel;
 		break;

--- a/etnaviv/etnaviv_module.c
+++ b/etnaviv/etnaviv_module.c
@@ -42,7 +42,7 @@ static pointer etnaviv_setup(pointer module, pointer opts, int *errmaj,
 			   dev_names[i], strerror(errno));
 	}
 
-	*errmaj = LDR_NOHARDWARE;
+	*errmaj = LDR_MODSPECIFIC;
 	*errmin = 0;
 
 	return NULL;

--- a/etnaviv/etnaviv_xv.c
+++ b/etnaviv/etnaviv_xv.c
@@ -67,9 +67,6 @@ static XF86VideoFormatRec etnaviv_formats[] = {
 	}, {
 		.depth = 16,
 		.class = TrueColor,
-	}, {
-		.depth = 24,
-		.class = TrueColor,
 	},
 };
 

--- a/src/armada_drm.c
+++ b/src/armada_drm.c
@@ -649,7 +649,6 @@ static Bool armada_drm_PreInit(ScrnInfoPtr pScrn, int flags)
 {
 	struct common_drm_device *drm_dev;
 	rgb defaultWeight = { 0, 0, 0 };
-	int flags24;
 
 	if (pScrn->numEntities != 1)
 		return FALSE;
@@ -673,8 +672,7 @@ static Bool armada_drm_PreInit(ScrnInfoPtr pScrn, int flags)
 	pScrn->chipset = "fbdev";
 	pScrn->displayWidth = 640;
 
-	flags24 = Support24bppFb | Support32bppFb | SupportConvert24to32;
-	if (!xf86SetDepthBpp(pScrn, 0, 0, 0, flags24))
+	if (!xf86SetDepthBpp(pScrn, 0, 0, 0, Support32bppFb))
 		goto fail;
 
 	switch (pScrn->depth) {

--- a/src/armada_drm_xv.c
+++ b/src/armada_drm_xv.c
@@ -318,7 +318,6 @@ static XF86VideoEncodingRec OverlayEncodings[] = {
 static XF86VideoFormatRec OverlayFormats[] = {
 	{ 8,  PseudoColor },
 	{ 16, TrueColor },
-	{ 24, TrueColor },
 	{ 32, TrueColor },
 };
 

--- a/vivante/vivante.c
+++ b/vivante/vivante.c
@@ -253,32 +253,6 @@ static GCOps vivante_unaccel_GCOps = {
 static void
 vivante_ValidateGC(GCPtr pGC, unsigned long changes, DrawablePtr pDrawable)
 {
-#ifdef FB_24_32BIT
-	if (changes & GCTile && fbGetRotatedPixmap(pGC)) {
-		pGC->pScreen->DestroyPixmap(fbGetRotatedPixmap(pGC));
-		fbGetRotatedPixmap(pGC) = NULL;
-	}
-	if (pGC->fillStyle == FillTiled) {
-		PixmapPtr pOldTile = pGC->tile.pixmap;
-		PixmapPtr pNewTile;
-
-		if (pOldTile->drawable.bitsPerPixel != pDrawable->bitsPerPixel) {
-			pNewTile = fbGetRotatedPixmap(pGC);
-			if (!pNewTile || pNewTile->drawable.bitsPerPixel != pDrawable->bitsPerPixel) {
-				if (pNewTile)
-					pGC->pScreen->DestroyPixmap(pNewTile);
-				prepare_cpu_drawable(&pOldTile->drawable, CPU_ACCESS_RO);
-				pNewTile = fb24_32ReformatTile(pOldTile, pDrawable->bitsPerPixel);
-				finish_cpu_drawable(&pOldTile->drawable, CPU_ACCESS_RO);
-			}
-			if (pNewTile) {
-				fbGetRotatedPixmap(pGC) = pOldTile;
-				pGC->tile.pixmap = pNewTile;
-				changes |= GCTile;
-			}
-		}
-	}
-#endif
 	if (changes & GCTile) {
 		if (!pGC->tileIsPixel &&
 		    FbEvenTile(pGC->tile.pixmap->drawable.width *


### PR DESCRIPTION
Driver does not compile against newer versions of xorg.  This series of patches seems to fix the issue for me, but someone who actually understands the driver should take a serious look at the 3rd patch (removing 24bpp pixmap format support) before this is merged.  Driver version update is needed so that packages can calculate dependencies properly.